### PR TITLE
fix(json): explicitly use UTF-8 when reading JSON to avoid locale-dependent decode errors

### DIFF
--- a/src/Final.py
+++ b/src/Final.py
@@ -126,7 +126,7 @@ os.chdir(working_directory)
 #Jsons
 def load_and_copy_json(file_name):
     file_path = os.path.join(working_directory, "Resources/Json", file_name)
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         return json.load(file).copy()
     
 goods_and_magic_json= load_and_copy_json("goods.json")


### PR DESCRIPTION
On Windows systems where the default system encoding is not UTF-8
(e.g., Traditional Chinese Windows using cp950), reading JSON files
without an explicit encoding may trigger a UnicodeDecodeError when the
JSON contains UTF-8–encoded characters that cannot be represented in
the system’s code page.

Example error:
```UnicodeDecodeError: 'cp950' codec can't decode byte 0xC3...```

Explicitly specifying encoding="utf-8" ensures consistent and
locale-independent JSON loading across all environments.
